### PR TITLE
Dont link to guide on shopify.dev that still refers to Remix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a template for building a [Shopify app](https://shopify.dev/docs/apps/getting-started) using [React Router](https://reactrouter.com/).  It was forked from the [Shopify Remix app template](https://github.com/Shopify/shopify-app-template-remix) and converted to React Router.
 
-Rather than cloning this repo, you can use your preferred package manager and the Shopify CLI with [these steps](https://shopify.dev/docs/apps/getting-started/create).
+Rather than cloning this repo, follow the [Quick Start steps](https://github.com/Shopify/shopify-app-template-react-router#quick-start).
 
 Visit the [`shopify.dev` documentation](https://shopify.dev/docs/api/shopify-app-react-router) for more details on the React Router app package.
 


### PR DESCRIPTION
### WHY are these changes introduced?

Previously we linked to a guide on shopify.dev that refers to Remix.  This could have been confusing

### WHAT is this pull request doing?

Link to the quick start section instead.


### Checklist

All of this is N/A:

- ~~[ ] I have made changes to the `README.md` file and other related documentation, if applicable~~
- ~~[ ] I have added an entry to `CHANGELOG.md`~~
- ~~[ ] I'm aware I need to create a new release when this PR is merged~~