### PR TITLE
Remove local CLI from package.json as the Shopify CLI reccomends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025.08.17
 
+- [#56](https://github.com/Shopify/shopify-app-template-react-router/pull/56) Remove local CLI from package.json in favor of global CLI installation
 - [#53](https://github.com/Shopify/shopify-app-template-react-router/pull/53) Add the Shopify Dev MCP to the template
 
 ## 2025.08.16

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@react-router/node": "^7.0.0",
     "@react-router/serve": "^7.0.0",
     "@shopify/app-bridge-react": "^4.1.6",
-    "@shopify/cli": "^3.63.1",
     "@shopify/shopify-app-react-router": "^0.1.1",
     "@shopify/shopify-app-session-storage-prisma": "^6.0.0",
     "isbot": "^5.1.0",


### PR DESCRIPTION
### WHY are these changes introduced?

We recommend a global installation of the Shopify CLI:  https://shopify.dev/docs/api/shopify-cli.  It will even warn when running `shopify app dev` if there are local & global installs.

### WHAT is this pull request doing?

Remove the local installation of the CLI defined in `package.json`.  Out Readme already tells users to setup the CLI, so no further changes should be needed.

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#<your-branch-name>
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged