### PR TITLE
Updated webhook API version to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025.08.17
 
+- [#57](https://github.com/Shopify/shopify-app-template-react-router/pull/57) Update Webhook API version in `shopify.app.toml` to `2025-07`
 - [#56](https://github.com/Shopify/shopify-app-template-react-router/pull/56) Remove local CLI from package.json in favor of global CLI installation
 - [#53](https://github.com/Shopify/shopify-app-template-react-router/pull/53) Add the Shopify Dev MCP to the template
 

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -3,7 +3,7 @@
 scopes = "write_products"
 
 [webhooks]
-api_version = "2024-10"
+api_version = "2025-07"
 
   # Handled by: /app/routes/webhooks.app.uninstalled.tsx
   [[webhooks.subscriptions]]


### PR DESCRIPTION
### WHY are these changes introduced?

The template should use the latest version of our API's

### WHAT is this pull request doing?

Use the latest version of our API in the webhook config.

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#update-webhook-api-version
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [X] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged