### PR TITLE
[WIP][Feature] Add admin authenticate middleware to "/app" routes

### DIFF
--- a/app/context.ts
+++ b/app/context.ts
@@ -1,0 +1,5 @@
+import { createContext } from "react-router";
+import { authenticate } from "./shopify.server";
+
+export const authenticatedAdminContext =
+  createContext<Awaited<ReturnType<typeof authenticate.admin>>>();

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -1,22 +1,11 @@
+import { Route } from "./+types/app._index";
 import { useEffect } from "react";
-import type {
-  ActionFunctionArgs,
-  HeadersFunction,
-  LoaderFunctionArgs,
-} from "react-router";
 import { useFetcher } from "react-router";
 import { useAppBridge } from "@shopify/app-bridge-react";
-import { authenticate } from "../shopify.server";
-import { boundary } from "@shopify/shopify-app-react-router/server";
+import { authenticatedAdminContext } from "../context";
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
-  await authenticate.admin(request);
-
-  return null;
-};
-
-export const action = async ({ request }: ActionFunctionArgs) => {
-  const { admin } = await authenticate.admin(request);
+export const action = async ({ context }: Route.ActionArgs) => {
+  const { admin } = context.get(authenticatedAdminContext);
   const color = ["Red", "Orange", "Yellow", "Green"][
     Math.floor(Math.random() * 4)
   ];
@@ -247,7 +236,3 @@ export default function Index() {
     </s-page>
   );
 }
-
-export const headers: HeadersFunction = (headersArgs) => {
-  return boundary.headers(headersArgs);
-};

--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -1,13 +1,21 @@
-import type { HeadersFunction, LoaderFunctionArgs } from "react-router";
+import { Route } from "./+types/app";
 import { Outlet, useLoaderData, useRouteError } from "react-router";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 import { AppProvider } from "@shopify/shopify-app-react-router/react";
-
 import { authenticate } from "../shopify.server";
+import { authenticatedAdminContext } from "../context";
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
-  await authenticate.admin(request);
+const adminAuthMiddleware: Route.MiddlewareFunction = async ({
+  request,
+  context,
+}) => {
+  const adminContext = await authenticate.admin(request);
+  context.set(authenticatedAdminContext, adminContext);
+};
 
+export const middleware: Route.MiddlewareFunction[] = [adminAuthMiddleware];
+
+export const loader = async () => {
   // eslint-disable-next-line no-undef
   return { apiKey: process.env.SHOPIFY_API_KEY || "" };
 };
@@ -31,6 +39,6 @@ export function ErrorBoundary() {
   return boundary.error(useRouteError());
 }
 
-export const headers: HeadersFunction = (headersArgs) => {
+export const headers: Route.HeadersFunction = (headersArgs) => {
   return boundary.headers(headersArgs);
 };

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from "@react-router/dev/config";
+
+export default {
+  future: {
+    v8_middleware: true,
+  },
+} satisfies Config;


### PR DESCRIPTION
### WIP
This pull request is waiting on https://github.com/Shopify/shopify-app-template-react-router/pull/65 to be merged in to avoid merge conflicts about generated `Route` types.

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-app-template-react-router/issues/11 by adding admin authenticate middleware at the top level of `/app` route.
This change also protects the `/app/additional` page provided by this template, which currently lacks a loader with an `admin.authenticate` call and is publicly accessible outside of the Shopify Admin UI.

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged