### PR TITLE
Fix update-javascript-branch workflow

### DIFF
--- a/.github/workflows/update-javascript-branch.yml
+++ b/.github/workflows/update-javascript-branch.yml
@@ -1,4 +1,4 @@
-name: Create a PR to keep JavaScript branch up to date with main
+name: Update JavaScript branch
 
 on:
   push:
@@ -23,10 +23,11 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 20.x
-          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm add -D @shopify/eslint-plugin
+        run: |
+          pnpm install
+          pnpm add -D @shopify/eslint-plugin
 
       - name: Create temporary tsconfig file for transpilation
         run: |
@@ -92,7 +93,7 @@ jobs:
           git checkout -b temp_javascript_updates
           git commit -m "Convert template to Javascript"
           git checkout javascript || git checkout -b javascript
-          git pull origin javascript || true
+          git pull origin javascript || echo "No remote javascript branch yet"
           git checkout -
           git rebase -m -X theirs javascript
           git push -f origin temp_javascript_updates:javascript_updates


### PR DESCRIPTION
### WHY are these changes introduced?

The update-javascript-branch workflow is not working https://github.com/Shopify/shopify-app-template-react-router/actions/runs/18166413951

### WHAT is this pull request doing?

3 changes:

1. Remove pnpm caching. This was breaking the workflow since there is no pnpm-lock.yaml file in source control
2. Git pull could fail silently with just || true. Now it will echo a message if the javascript branch doesn't exist.  This wouldn't break the workflow, but better to not fail silently.

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#update-javascript-branch-workflow
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged