### PR TITLE
Update to v1 of `@shopify/shopify-app-react-router` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025.10.01
 
+- [#77](https://github.com/Shopify/shopify-app-template-react-router/pull/77) Update `@shopify/shopify-app-react-router` to V1.
 - [#73](https://github.com/Shopify/shopify-app-template-react-router/pull/73/files) Rename @shopify/app-bridge-ui-types to @shopify/polaris-types
 
 ## 2025.08.30

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@react-router/node": "^7.9.1",
     "@react-router/serve": "^7.9.1",
     "@shopify/app-bridge-react": "^4.1.6",
-    "@shopify/shopify-app-react-router": "^0.2.0",
+    "@shopify/shopify-app-react-router": "^1.0.0",
     "@shopify/shopify-app-session-storage-prisma": "^7.0.0",
     "isbot": "^5.1.0",
     "prisma": "^6.2.1",


### PR DESCRIPTION
### WHY are these changes introduced?

`@shopify/shopify-app-react-router` is now on V1.  We want to be on the latest

### WHAT is this pull request doing?

Update `@shopify/shopify-app-react-router` to V1.

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#v1-shopify-app-react-router-package
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged