### PR TITLE
add shopify global to eslint for ui extensions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -90,4 +90,7 @@ module.exports = {
       },
     },
   ],
+  globals: {
+    shopify: "readonly"
+  },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @shopify/shopify-app-template-react-router
 
+## 2025.10.02
+
+- [#81](https://github.com/Shopify/shopify-app-template-react-router/pull/81) Add shopify global to eslint for ui extensions
+
 ## 2025.10.01
 
 - [#79](https://github.com/Shopify/shopify-app-template-react-router/pull/78) Update API version to 2025-10.


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

a react router app that also has ui extensions added gives eslint errors for the shopify global used in ui extensions. The old remix app had this covered in the corresponding eslint config file

<img width="1035" height="434" alt="image" src="https://github.com/user-attachments/assets/a276e089-f517-4f57-9553-42ec15fc4934" />


### WHAT is this pull request doing?

This PR adds the shopify global to the eslint config file

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#add-shopify-global-to-eslint
```

- Add a checkout ui extension to a react router app with `shopify app generate extension`
- See that `shopify` references in `extensions/{extension-name}/src/Checkout.jsx` has eslint error

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged