### PR TITLE
[Fix] Add p-map override to fix ERR_REQUIRE_ESM errors in some environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20.10"
+    "node": ">=20.19 <22 || >=22.12"
   },
   "dependencies": {
     "@prisma/client": "^6.16.3",
@@ -66,5 +66,8 @@
   },
   "trustedDependencies": [
     "@shopify/plugin-cloudflare"
-  ]
+  ],
+  "overrides": {
+    "p-map": "^4.0.0"
+  }
 }


### PR DESCRIPTION
Fix ERR_REQUIRE_ESM errors that occur inconsistently across different Node.js and npm version
  combinations when running this app.

The @react-router/dev v7.x dependency chain pulls in p-map@^7.0.3, which is ESM-only. The compiled @react-router/dev code uses require(p-map) in its vite.js file. While Node.js v22.12.0+ and v20.19.0+ support require(esm) by default, some users still encounter ERR_REQUIRE_ESM errors even on Node v23.10.0 with npm 11.6.2. The exact conditions causing the error are not fully understood, but forcing p-map@^4.0.0 (CommonJS-compatible) resolves it across all reported cases. This is safe because @react-router/dev only uses basic p-map features (array mapping + concurrency option) that exist in both v4 and v7.


### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#add-pmap-override
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged