### PR TITLE
Migrate Prisma datasource config to prisma.config.ts and fix TS error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=20.19 <22 || >=22.12"
   },
   "dependencies": {
-    "@prisma/client": "^6.16.3",
+    "@prisma/client": "^7.0.0",
     "@react-router/dev": "^7.9.3",
     "@react-router/fs-routes": "^7.9.3",
     "@react-router/node": "^7.9.3",
@@ -33,7 +33,7 @@
     "@shopify/shopify-app-react-router": "^1.0.0",
     "@shopify/shopify-app-session-storage-prisma": "^7.0.0",
     "isbot": "^5.1.31",
-    "prisma": "^6.16.3",
+    "prisma": "^7.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router": "^7.9.3",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,11 @@
+import type { PrismaConfig } from "prisma";
+
+export default {
+  schema: 'prisma/schema.prisma',
+  migrations: {
+    path: 'prisma/migrations',
+  },
+  datasource: {
+    url: "file:./prisma/dev.sqlite",
+  },
+} satisfies PrismaConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,6 @@ generator client {
 // See https://www.prisma.io/docs/orm/reference/prisma-schema-reference#string for more information
 datasource db {
   provider = "sqlite"
-  url      = "file:dev.sqlite"
 }
 
 model Session {


### PR DESCRIPTION
## WHY are these changes introduced?

Prisma rolled out a new config system. The old datasource url in schema.prisma now throws a TS error. This PR migrates the URL to prisma.config.ts.
<img width="1920" height="1080" alt="Screenshot from 2025-11-24 03-06-52" src="https://github.com/user-attachments/assets/c74c97f0-85cc-4e81-bc2e-585985a9e5c2" />


## WHAT is this pull request doing?

Adds prisma.config.ts

Removes datasource url from schema.prisma

