### PR TITLE
Added name field example in shopify.app.toml for pubSub toml example

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -33,17 +33,21 @@ api_version = "2024-07"
   # uri = "/webhooks/products/update"
   # filter = "variants.price:>=10.00"
 
+  # Webhooks can have names as identifiers
+  # This field is optional
+  # Must be unique; alphanumeric characters, underscores, and hyphens only
+  # [[webhooks.subscriptions]]
+  # name = "products-create"
+  # topics = [ "products/create" ]
+  # uri = "/webhooks/products/create"
+
   # Mandatory compliance topic for public apps only
   # See: https://shopify.dev/docs/apps/build/privacy-law-compliance
   # [[webhooks.subscriptions]]
   # uri = "/webhooks/customers/data_request"
   # compliance_topics = ["customers/data_request"]
 
-  # Webhooks can have names as identifiers
-  # This field is optional
-  # Must be unique; alphanumeric characters, underscores, and hyphens only
   # [[webhooks.subscriptions]]
-  # name = "customers-redact"
   # uri = "/webhooks/customers/redact"
   # compliance_topics = ["customers/redact"]
 


### PR DESCRIPTION
closes: https://github.com/shop/issues-event-foundations/issues/602
Added an example to showcase how you can add a name field to a webhook subscription in the `shopify.app.toml` file