### PR TITLE
added an example with the optional name field to eventBridge example

### DIFF
--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -37,6 +37,7 @@ api_version = "2024-07"
   # This field is optional
   # Must be unique; alphanumeric characters, underscores, and hyphens only
   # [[webhooks.subscriptions]]
+  # name = "products-create"
   # topics = [ "products/create" ]
   # uri = "/webhooks/products/create"
 


### PR DESCRIPTION
closes: https://github.com/shop/issues-event-foundations/issues/603
Added an example webhook in the shopify.app.toml with an optional name field to show devs how to name their webhooks