### PR TITLE
Avoid npx in shopify.web.toml

### DIFF
--- a/shopify.web.toml
+++ b/shopify.web.toml
@@ -1,7 +1,0 @@
-name = "React Router"
-roles = ["frontend", "backend"]
-webhooks_path = "/webhooks/app/uninstalled"
-
-[commands]
-predev = "npx prisma generate"
-dev = "npx prisma migrate deploy && npm exec react-router dev"

--- a/shopify.web.toml.liquid
+++ b/shopify.web.toml.liquid
@@ -1,0 +1,11 @@
+name = "React Router"
+roles = ["frontend", "backend"]
+webhooks_path = "/webhooks/app/uninstalled"
+
+{%- assign exec = dependency_manager | append: ' exec' -%}
+{%- if dependency_manager == 'yarn' -%}
+{%- assign exec = 'yarn' -%}
+{%- endif %}
+[commands]
+predev = "{{ exec }} prisma generate"
+dev = "{{ exec }} prisma migrate deploy && {{ exec }} react-router dev"


### PR DESCRIPTION
### WHY are these changes introduced?

We are hardcoding `npx` in the shopify.web.toml and it causes `shopify app dev` to fail when it's not available.

### WHAT is this pull request doing?

Run the commands using the current package manager of the project

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#remove-npx
shopify app dev
```

### Checklist

- [ ] I have made changes to the `README.md` file and other related documentation, if applicable
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I'm aware I need to create a new release when this PR is merged