### PR TITLE
Fix text overlap in mutation output panels

### DIFF
--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -237,7 +237,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>{JSON.stringify(fetcher.data.product, null, 2)}</code>
                 </pre>
               </s-box>
@@ -249,7 +255,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>{JSON.stringify(fetcher.data.variant, null, 2)}</code>
                 </pre>
               </s-box>
@@ -261,7 +273,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>
                     {JSON.stringify(fetcher.data.metaobject, null, 2)}
                   </code>


### PR DESCRIPTION
## Summary
- The `<pre>` blocks in `app/routes/app._index.tsx` rendering `JSON.stringify` output used the default `white-space: pre`, so long string values (the metaobject description in particular) ran past the right edge of `<s-box>` and overlapped adjacent layout — see the screenshot in the [original report](https://shopify.slack.com/archives/D097P8E12N1/p1763324496055399).
- Applies `whiteSpace: "pre-wrap"` + `wordBreak: "break-word"` to all three panels (productCreate, productVariantsBulkUpdate, metaobjectUpsert) so output stays within its container. The other two will hit the same issue the moment any field grows.

## Test plan
- [ ] Run the template, click **Generate a product**, verify the metaobjectUpsert panel wraps the long `description.jsonValue` instead of overflowing.
- [ ] Confirm the productCreate and productVariantsBulkUpdate panels still render correctly.
- [ ] After merge, confirm `update-javascript-cli-branch.yml` propagates the change to `javascript-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)