### PR TITLE
Unbreak CI: pnpm 10, Node matrix refresh, prisma generate ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20.19.0, 22, 24]
+        node: [22, 24, 26]
         manager: ['npm', 'yarn', 'pnpm']
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         if: ${{ matrix.manager == 'pnpm' }}
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Install dependencies using ${{ matrix.manager }}
         run: ${{ matrix.manager }} install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
       - name: Install dependencies using ${{ matrix.manager }}
         run: ${{ matrix.manager }} install
 
+      - name: Validate Prisma
+        run: npx prisma generate && npx prisma validate
+
       - name: Run TypeScript type checking
         if: ${{ !startsWith(github.head_ref || github.ref_name, 'javascript') }}
         run: npx tsc --noEmit
 
       - name: Run ESLint
         run: npm run lint
-
-      - name: Validate Prisma
-        run: npx prisma generate && npx prisma validate
 
       - name: Build application
         run: npm run build

--- a/.github/workflows/convert-to-javascript.yml
+++ b/.github/workflows/convert-to-javascript.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Summary
Three CI fixes bundled together. Each was uncovered when the previous one stopped masking the next.

### 1. Bump `pnpm/action-setup` from v8 to v10 (`ci.yml`, `convert-to-javascript.yml`)
`@shopify/polaris-types@1.0.7` (resolved on `main-cli` via the caret range) sets `engines.pnpm: >=10.2.0`. CI was pinned to pnpm 8.15.9, which tripped `ERR_PNPM_UNSUPPORTED_ENGINE` on the pnpm matrix legs. Bumping the action pin to 10 also covers the `convert-to-javascript.yml` reusable workflow.

### 2. Drop Node 20 from the matrix, add Node 26 (`ci.yml`)
Same `polaris-types@1.0.7` also bumped `engines.node` to `>=22.18.0`, so the Node 20.19.0 legs were failing post-pnpm-fix. Rather than just removing 20, refresh the matrix to align with the Node support calendar: `[22, 24, 26]`.

### 3. Run `prisma generate` before `tsc --noEmit` (`ci.yml`)
With install and Node sorted, typecheck started failing with `TS2305: Module '"@prisma/client"' has no exported member 'PrismaClient'`. `@prisma/client` only exports its types after `prisma generate` runs, and the workflow had the Validate Prisma step *after* the TypeScript type checking step. Reorder so generated types exist when tsc runs. This was a latent bug previously hidden by the install failure.

## Test plan
- [ ] CI matrix passes on all three Node versions (22, 24, 26) across npm, yarn, and pnpm
- [ ] `convert-to-javascript` workflow still runs successfully when triggered