### PR TITLE
Drop Node 20 from CI matrix, add Node 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20.19.0, 22, 24]
+        node: [22, 24, 26]
         manager: ['npm', 'yarn', 'pnpm']
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,15 +25,15 @@ jobs:
       - name: Install dependencies using ${{ matrix.manager }}
         run: ${{ matrix.manager }} install
 
+      - name: Validate Prisma
+        run: npx prisma generate && npx prisma validate
+
       - name: Run TypeScript type checking
         if: ${{ !startsWith(github.head_ref || github.ref_name, 'javascript') }}
         run: npx tsc --noEmit
 
       - name: Run ESLint
         run: npm run lint
-
-      - name: Validate Prisma
-        run: npx prisma generate && npx prisma validate
 
       - name: Build application
         run: npm run build

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -237,7 +237,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>{JSON.stringify(fetcher.data.product, null, 2)}</code>
                 </pre>
               </s-box>
@@ -249,7 +255,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>{JSON.stringify(fetcher.data.variant, null, 2)}</code>
                 </pre>
               </s-box>
@@ -261,7 +273,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>
                     {JSON.stringify(fetcher.data.metaobject, null, 2)}
                   </code>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@react-router/serve": "^7.12.0",
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.1.0",
-    "@shopify/shopify-app-session-storage-prisma": "^8.0.0",
+    "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
     "isbot": "^5.1.31",
     "prisma": "^6.16.3",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- `@shopify/polaris-types@1.0.7` also bumped `engines.node` to `>=22.18.0`, so the Node 20.19.0 legs fail to install once the pnpm fix lands.
- Refresh the matrix to align with the Node support calendar: `[22, 24, 26]`.

## Stack
PR 2 of 5. Stacked on #246.

## Test plan
- [ ] CI runs on Node 22, 24, 26