### PR TITLE
Bump @shopify/shopify-app-session-storage-prisma to ^9

### DIFF
--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -237,7 +237,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>{JSON.stringify(fetcher.data.product, null, 2)}</code>
                 </pre>
               </s-box>
@@ -249,7 +255,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>{JSON.stringify(fetcher.data.variant, null, 2)}</code>
                 </pre>
               </s-box>
@@ -261,7 +273,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>
                     {JSON.stringify(fetcher.data.metaobject, null, 2)}
                   </code>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@react-router/serve": "^7.12.0",
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.1.0",
-    "@shopify/shopify-app-session-storage-prisma": "^8.0.0",
+    "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
     "isbot": "^5.1.31",
     "prisma": "^6.16.3",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- v8 pulls in an older `@shopify/shopify-api` that npm hoists at the top of `node_modules`, alongside the copy nested under `@shopify/shopify-app-react-router`.
- Two physical copies of the `Session` type → tsc sees them as nominally distinct and fails on the npm matrix legs with `TS2322` in `app/shopify.server.ts`. pnpm and yarn dedupe correctly so they hid the issue.
- v9 aligns the peer-required `shopify-api` version so the tree dedupes uniformly across all three package managers.

## Stack
PR 4 of 5. Stacked on #248.

## Test plan
- [ ] npm matrix legs pass typecheck
- [ ] Application boots locally with the new session storage version