### PR TITLE
Add pnpm-workspace.yaml with workspace config and allowBuilds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+packages:
+  - 'extensions/*'
+allowBuilds:
+  '@parcel/watcher': true
+  '@prisma/client': true
+  '@prisma/engines': true
+  esbuild: true
+  prisma: true
+  unrs-resolver: true


### PR DESCRIPTION
pnpm 11 blocks dependency build scripts by default, causing `pnpm install` to fail with `ERR_PNPM_IGNORED_BUILDS`.

Adds `pnpm-workspace.yaml` with:
- `packages` config (pnpm equivalent of the `workspaces` field in `package.json`)
- `allowBuilds` entries for dependencies that require build scripts

Compatible with pnpm 7+.