### PR TITLE
Backport PRs #246-#250 to main-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20.19.0, 22, 24]
+        node: [22, 24, 26]
         manager: ['npm', 'yarn', 'pnpm']
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -20,10 +20,13 @@ jobs:
         if: ${{ matrix.manager == 'pnpm' }}
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Install dependencies using ${{ matrix.manager }}
         run: ${{ matrix.manager }} install
+
+      - name: Validate Prisma
+        run: npx prisma generate && npx prisma validate
 
       - name: Run TypeScript type checking
         if: ${{ !startsWith(github.head_ref || github.ref_name, 'javascript') }}
@@ -31,9 +34,6 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
-
-      - name: Validate Prisma
-        run: npx prisma generate && npx prisma validate
 
       - name: Build application
         run: npm run build

--- a/.github/workflows/convert-to-javascript.yml
+++ b/.github/workflows/convert-to-javascript.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -237,7 +237,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>{JSON.stringify(fetcher.data.product, null, 2)}</code>
                 </pre>
               </s-box>
@@ -249,7 +255,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>{JSON.stringify(fetcher.data.variant, null, 2)}</code>
                 </pre>
               </s-box>
@@ -261,7 +273,13 @@ export default function Index() {
                 borderRadius="base"
                 background="subdued"
               >
-                <pre style={{ margin: 0 }}>
+                <pre
+                  style={{
+                    margin: 0,
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
                   <code>
                     {JSON.stringify(fetcher.data.metaobject, null, 2)}
                   </code>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@react-router/serve": "^7.12.0",
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.1.0",
-    "@shopify/shopify-app-session-storage-prisma": "^8.0.0",
+    "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
     "isbot": "^5.1.31",
     "prisma": "^6.16.3",
     "react": "^18.3.1",


### PR DESCRIPTION
Backports the following merged PRs to `main-cli`:

- **#250** Fix text overlap in mutation output panels (+21/-3)
- **#249** Bump `@shopify/shopify-app-session-storage-prisma` to ^9 (+1/-1)
- **#248** Run prisma generate before TypeScript type checking (+3/-3)
- **#247** Drop Node 20 from CI matrix, add Node 26 (+1/-1)
- **#246** Bump CI pnpm version from 8 to 10 (+2/-2)