### PR TITLE
[#metaobjects] Use values API on Admin API 2026-07

### DIFF
--- a/.graphqlrc.ts
+++ b/.graphqlrc.ts
@@ -8,8 +8,11 @@ function getConfig() {
     projects: {
       default: shopifyApiProject({
         apiType: ApiType.Admin,
-        apiVersion: ApiVersion.October25,
-        documents: ["./app/**/*.{js,ts,jsx,tsx}", "./app/.server/**/*.{js,ts,jsx,tsx}"],
+        apiVersion: ApiVersion.July26,
+        documents: [
+          "./app/**/*.{js,ts,jsx,tsx}",
+          "./app/.server/**/*.{js,ts,jsx,tsx}",
+        ],
         outputDir: "./app/types",
       }),
     },

--- a/app/routes/app._index.tsx
+++ b/app/routes/app._index.tsx
@@ -89,17 +89,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const metaobjectResponse = await admin.graphql(
     `#graphql
-    mutation shopifyReactRouterTemplateUpsertMetaobject($handle: MetaobjectHandleInput!, $metaobject: MetaobjectUpsertInput!) {
-      metaobjectUpsert(handle: $handle, metaobject: $metaobject) {
+    mutation shopifyReactRouterTemplateUpsertMetaobject($handle: MetaobjectHandleInput!, $values: JSON!) {
+      metaobjectUpsert(handle: $handle, values: $values) {
         metaobject {
           id
           handle
-          title: field(key: "title") {
-            jsonValue
-          }
-          description: field(key: "description") {
-            jsonValue
-          }
+          values
         }
         userErrors {
           field
@@ -113,15 +108,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
           type: "$app:example",
           handle: "demo-entry",
         },
-        metaobject: {
-          fields: [
-            { key: "title", value: "Demo Entry" },
-            {
-              key: "description",
-              value:
-                "This metaobject was created by the Shopify app template to demonstrate the metaobject API.",
-            },
-          ],
+        values: {
+          title: "Demo Entry",
+          description:
+            "This metaobject was created by the Shopify app template to demonstrate the metaobject API.",
         },
       },
     },
@@ -133,8 +123,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     product: responseJson!.data!.productCreate!.product,
     variant:
       variantResponseJson!.data!.productVariantsBulkUpdate!.productVariants,
-    metaobject:
-      metaobjectResponseJson!.data!.metaobjectUpsert!.metaobject,
+    metaobject: metaobjectResponseJson!.data!.metaobjectUpsert!.metaobject,
   };
 };
 

--- a/app/shopify.server.ts
+++ b/app/shopify.server.ts
@@ -10,7 +10,7 @@ import prisma from "./db.server";
 const shopify = shopifyApp({
   apiKey: process.env.SHOPIFY_API_KEY,
   apiSecretKey: process.env.SHOPIFY_API_SECRET || "",
-  apiVersion: ApiVersion.October25,
+  apiVersion: ApiVersion.July26,
   scopes: process.env.SCOPES?.split(","),
   appUrl: process.env.SHOPIFY_APP_URL || "",
   authPathPrefix: "/auth",
@@ -25,7 +25,7 @@ const shopify = shopifyApp({
 });
 
 export default shopify;
-export const apiVersion = ApiVersion.October25;
+export const apiVersion = ApiVersion.July26;
 export const addDocumentResponseHeaders = shopify.addDocumentResponseHeaders;
 export const authenticate = shopify.authenticate;
 export const unauthenticated = shopify.unauthenticated;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@react-router/node": "^7.12.0",
     "@react-router/serve": "^7.12.0",
     "@shopify/app-bridge-react": "^4.2.4",
-    "@shopify/shopify-app-react-router": "^1.1.0",
+    "@shopify/shopify-app-react-router": "^1.2.1",
     "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
     "isbot": "^5.1.31",
     "prisma": "^6.16.3",

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -28,7 +28,7 @@ name = "Description"
 type = "multi_line_text_field"
 
 [webhooks]
-api_version = "2025-10"
+api_version = "2026-07"
 
   # Handled by: /app/routes/webhooks.app.uninstalled.tsx
   [[webhooks.subscriptions]]


### PR DESCRIPTION
> [!WARNING]
> Make sure JS flavour branch is updated afterward.

FYI: bumps default API version up to 2026-07.

Metaobject reads and writes now use the JSON [`values` interface](https://shopify.dev/docs/api/admin-graphql/2026-07/mutations/metaobjectUpsert), available from Admin API 2026-07, so the template demonstrates the preferred API rather than field-by-field payloads.

The upsert supplies the complete declared value set, preserving behaviour under `values`' full-replacement semantics. Runtime requests, GraphQL codegen, and webhook configuration target 2026-07; the `@shopify/shopify-app-react-router` minimum version supplies `ApiVersion.July26`.
