### PR TITLE
[#template-ci] Run JavaScript conversion with Node 24

### DIFF
--- a/.github/workflows/convert-to-javascript.yml
+++ b/.github/workflows/convert-to-javascript.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The [JavaScript CLI conversion workflow](https://github.com/Shopify/shopify-app-template-react-router/actions/runs/29241095850/job/86787078376) can install current template dependencies again by running on Node 24 instead of Node 20.

`@shopify/polaris-types@1.0.7` requires Node 22.18 or newer, while the reusable converter selected Node 20. Node 24 is already covered by the `main-cli` CI matrix, so the conversion uses a runtime the branch continuously validates.
