### PR TITLE
Move shamefully-hoist from .npmrc to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-shamefully-hoist=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'extensions/*'
+shamefullyHoist: true
 allowBuilds:
   '@parcel/watcher': true
   '@prisma/client': true


### PR DESCRIPTION
Fixes #261

Every npm command in an app from this template prints:

```
npm warn Unknown project config "shamefully-hoist". This will stop working in the next major version of npm.
```

`shamefully-hoist` is pnpm-specific, so npm doesn't recognise it. It isn't reaching pnpm either — pnpm reads its settings from `pnpm-workspace.yaml` rather than `.npmrc`, so the hoisting has silently stopped happening: on `main-cli` with pnpm 11.13, a fresh install leaves 21 packages in the root `node_modules` instead of the 545 the setting is meant to hoist.

- `.npmrc` — drops `shamefully-hoist=true`. `engine-strict=true` stays, since npm supports it.
- `pnpm-workspace.yaml` — adds `shamefullyHoist: true`, alongside the `allowBuilds` entries already there.

No `CHANGELOG.md` entry, matching #254 and the earlier `.npmrc` changes in 5d6988e and 38377c2 — happy to add one if you'd rather this were recorded.

Verified against clean checkouts of `main-cli` and this branch: root `node_modules` goes from 21 to 545, the npm warning goes from 1 to 0, and `prisma generate && prisma validate`, `tsc --noEmit`, `lint` and `build` all pass with pnpm 11.13 and with npm 11.16. I couldn't run the yarn leg — yarn isn't installed on my machine.

Test this PR:

```bash
shopify app init --template=https://github.com/Fransuelton/shopify-app-template-react-router#fix/npmrc-pnpm-only-setting
```
