### PR TITLE
Replace CLAUDE.md symlink with Claude Code import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
Related to https://github.com/shop/issues-develop/issues/22870

Replace the CLAUDE.md symlink with Claude Code’s @AGENTS.md import directive. This keeps the shared instructions loaded in Claude Code while supporting Windows checkouts without symlink support.

Replaces prior PR: https://github.com/Shopify/shopify-app-template-react-router/pull/269
