### PR TITLE
[main-cli] Mark the App Nav home route

### DIFF
--- a/app/routes/app.tsx
+++ b/app/routes/app.tsx
@@ -18,7 +18,8 @@ export default function App() {
   return (
     <AppProvider embedded apiKey={apiKey}>
       <s-app-nav>
-        <s-link href="/app">Home</s-link>
+        {/* @ts-expect-error -- rel="home" is supported by App Bridge but missing from @shopify/polaris-types@1.0.7 */}
+        <s-link href="/app" rel="home">Home</s-link>
         <s-link href="/app/additional">Additional page</s-link>
       </s-app-nav>
       <Outlet />

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@shopify/api-codegen-preset": "^1.2.0",
-    "@shopify/polaris-types": "^1.0.1",
+    "@shopify/polaris-types": "^1.0.7",
     "@types/eslint": "^9.6.1",
     "@types/node": "^22.18.8",
     "@types/react": "^18.3.25",


### PR DESCRIPTION
## Why

The CLI TypeScript template's embedded app home is mounted at `/app`. App Bridge defaults the app home route to `/`, so the documented `rel="home"` relationship is required to designate `/app` as the home route and keep the configuration link out of the rendered sub-navigation.

## What changed

- Add `rel="home"` to the `/app` `s-link`.
- Update `@shopify/polaris-types` to the latest published version, 1.0.7.
- Keep a narrow `@ts-expect-error` because 1.0.7 still omits the documented `rel` attribute from the `s-link` JSX type. The directive will fail as unused once the upstream type is fixed, prompting its removal.

This targets `main-cli`; its existing workflow will generate the corresponding `javascript-cli` conversion PR.

Docs: https://shopify.dev/docs/api/app-home/app-bridge-web-components/app-nav

## Validation

- `pnpm prisma generate`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
