### PR TITLE
Pin React Router to 7.18.2 and force qs to ^6.16.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,11 @@ updates:
       # versions in package.json once the template adopts `allowedActionOrigins`
       # (which also needs a build-time story for `react-router-serve`, since the
       # value is baked into the production build).
+      #
+      # NOTE: ignore rules apply to Dependabot SECURITY updates as well as
+      # version updates, so a react-router security release above 7.18.2 will
+      # NOT produce a Dependabot PR while these entries stand. Watch upstream
+      # advisories through other channels until the pin is lifted.
       - dependency-name: 'react-router'
         versions: ['>7.18.2']
       - dependency-name: '@react-router/dev'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,31 @@ updates:
       semver-minor-days: 14
       semver-patch-days: 14
 
+    ignore:
+      # Hold the react-router family at the version pinned in package.json.
+      # react-router 7.18.3 tightened action-origin validation from host-only to
+      # full origin (scheme + host + port) in remix-run/react-router#15420. Under
+      # `shopify app dev` TLS terminates at the tunnel and the app server sees a
+      # plain-http request URL, so `Origin: https://<host>` no longer matches and
+      # every action POST returns 400. See issue #279.
+      #
+      # Upstream treats the new behaviour as correct and prescribes the
+      # `allowedActionOrigins` config option rather than a fix, so these ignores
+      # are not waiting on a patch release. Remove them together with the exact
+      # versions in package.json once the template adopts `allowedActionOrigins`
+      # (which also needs a build-time story for `react-router-serve`, since the
+      # value is baked into the production build).
+      - dependency-name: 'react-router'
+        versions: ['>7.18.2']
+      - dependency-name: '@react-router/dev'
+        versions: ['>7.18.2']
+      - dependency-name: '@react-router/fs-routes'
+        versions: ['>7.18.2']
+      - dependency-name: '@react-router/node'
+        versions: ['>7.18.2']
+      - dependency-name: '@react-router/serve'
+        versions: ['>7.18.2']
+
     groups:
 
       # Group together PRs of dependant packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @shopify/shopify-app-template-react-router
 
+## 2026.09.03
+
+- [#280](https://github.com/Shopify/shopify-app-template-react-router/pull/280) Pin the React Router family to 7.18.2. 7.18.3 tightened action-origin validation to compare the full origin, which made every action return `400 Bad Request` under `shopify app dev` and behind any TLS-terminating proxy in production. Fixes [#279](https://github.com/Shopify/shopify-app-template-react-router/issues/279).
+- [#280](https://github.com/Shopify/shopify-app-template-react-router/pull/280) Force `qs` to `^6.16.0` to clear [CVE-2026-82562](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) and [CVE-2026-82417](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g), which reach the app transitively through `@react-router/serve` → `express@4`.
+
 ## 2026.01.08
 - [#170](https://github.com/Shopify/shopify-app-template-react-router/pull/170) - Update React Router minimum version to v7.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # @shopify/shopify-app-template-react-router
 
 ## 2026.09.03
-
-- [#280](https://github.com/Shopify/shopify-app-template-react-router/pull/280) Pin the React Router family to 7.18.2. 7.18.3 tightened action-origin validation to compare the full origin, which made every action return `400 Bad Request` under `shopify app dev` and behind any TLS-terminating proxy in production. Fixes [#279](https://github.com/Shopify/shopify-app-template-react-router/issues/279).
-- [#280](https://github.com/Shopify/shopify-app-template-react-router/pull/280) Force `qs` to `^6.16.0` to clear [CVE-2026-82562](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) and [CVE-2026-82417](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g), which reach the app transitively through `@react-router/serve` → `express@4`.
+- [#280](https://github.com/Shopify/shopify-app-template-react-router/pull/280) - Pin the React Router family to 7.18.2. 7.18.3 tightened action-origin validation to compare the full origin, which made every action return `400 Bad Request` under `shopify app dev` and, in production, behind TLS-terminating proxies that forward to the app over plain HTTP (`react-router-serve` never enables Express `trust proxy`). Fixes [#279](https://github.com/Shopify/shopify-app-template-react-router/issues/279).
+- [#280](https://github.com/Shopify/shopify-app-template-react-router/pull/280) - Force `qs` to `^6.16.0` to clear [CVE-2026-82562](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) and [CVE-2026-82417](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g), which reach the app transitively through `@react-router/serve` → `express@4`.
 
 ## 2026.01.08
 - [#170](https://github.com/Shopify/shopify-app-template-react-router/pull/170) - Update React Router minimum version to v7.12.0

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "dependencies": {
     "@prisma/client": "^6.16.3",
-    "@react-router/dev": "^7.12.0",
-    "@react-router/fs-routes": "^7.12.0",
-    "@react-router/node": "^7.12.0",
-    "@react-router/serve": "^7.12.0",
+    "@react-router/dev": "7.18.2",
+    "@react-router/fs-routes": "7.18.2",
+    "@react-router/node": "7.18.2",
+    "@react-router/serve": "7.18.2",
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
@@ -36,7 +36,7 @@
     "prisma": "^6.16.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.12.0",
+    "react-router": "7.18.2",
     "vite-tsconfig-paths": "^6.0.4"
   },
   "devDependencies": {
@@ -68,6 +68,15 @@
     "@shopify/plugin-cloudflare"
   ],
   "overrides": {
-    "p-map": "^4.0.0"
+    "p-map": "^4.0.0",
+    "qs": "^6.16.0"
+  },
+  "resolutions": {
+    "qs": "^6.16.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "qs": "^6.16.0"
+    }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #279

Two unrelated problems, both surfaced this week, both reaching every freshly scaffolded app.

**1. Every action returns `400 Bad Request` (issue #279)**

`react-router@7.18.3` (published 2026-08-28) tightened action-origin validation from a host-only comparison to a full-origin comparison in [remix-run/react-router#15420](https://github.com/remix-run/react-router/pull/15420):

```js
// 7.18.2
let host = new URL(request.url).host;
if (originDomain && originDomain !== host) {

// 7.18.3
let requestUrl = new URL(request.url);
let originMatchesRequest = originUrl ? originUrl.origin === requestUrl.origin : originDomain === requestUrl.host;
if (originDomain && !originMatchesRequest) {
```

Under `shopify app dev`, TLS terminates at the Cloudflare edge and the CLI's own reverse proxy forwards to the app over plain HTTP **without** setting `X-Forwarded-Proto`. The app therefore computes `request.url` as `http://<tunnel-host>` while the browser sends `Origin: https://<tunnel-host>`. The two origins differ on scheme alone, so every action POST 400s at `singleFetchAction`. Loaders and GETs are unaffected.

Because the ranges were `^7.12.0`, every scaffold created on or after 2026-08-28 resolved 7.18.3 and hit this — which is how it reached a partner through the [Scaffold an app tutorial](https://shopify.dev/docs/apps/build/scaffold-app).

This is **not dev-only**. `@react-router/serve` never enables Express `trust proxy`, so a deployed app behind any TLS-terminating proxy computes `http:` the same way and 400s identically. Verified on `react-router-serve` with `NODE_ENV=production`.

**2. Two `qs` CVEs on the request path**

`qs@6.15.3` arrives transitively via `@react-router/serve` → `@react-router/express` → `express@4.22.2`, and is vulnerable to [CVE-2026-82562](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) and [CVE-2026-82417](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g) (both medium, both fixed in 6.16.0). This one sits closer to the request path than the deepmerge-ts finding below — express parses every query string with `qs` — though neither advisory's failure mode fires inside express's own calls (express never sets `comma: true`, the first advisory's precondition, and never calls `qs.stringify`, the second's sink). Express does parse with `allowPrototypes: true`, which delivers exactly the malicious shape the second advisory needs into `req.query`, one app-level `qs.stringify(req.query)` away from a crash — so the override is cheap defense-in-depth, not a live-hole fix.

### WHAT is this pull request doing?

- **Pins all five `react-router` packages to `7.18.2`**, restoring host-only origin checking for both dev and production.
- **Forces `qs` to `^6.16.0`**, clearing both CVEs.
- **Adds Dependabot `ignore` entries** holding the family at `>7.18.2`, so the `react-router` group doesn't immediately revert the pin.
- **Adds a `CHANGELOG.md` entry.**

The `qs` override is declared in **three dialects** — npm `overrides`, `resolutions`, and `pnpm.overrides` — because CI installs with npm, yarn *and* pnpm, and each honours a different field. Verified directly: **pnpm silently ignores npm's `overrides`**, which also means the pre-existing `p-map` override has been a no-op for pnpm and yarn users since #113. (pnpm 8/10 do honour `resolutions`, merging it with `pnpm.overrides`, so the pnpm block is explicit rather than strictly required — and pnpm 11 stops reading the `pnpm` field of package.json entirely, so `resolutions` is the durable spelling.) I deliberately did **not** extend `p-map` into the new fields — that would newly downgrade pnpm/yarn users from `p-map@7.0.7` to `4.0.0`, an unrelated behaviour change that shouldn't ride along with a security patch. Worth a follow-up.

`^6.16.0` is written as a range rather than an exact pin because an exact value is the sole trigger for yarn classic's `Resolution field ... is incompatible with requested version` warning; the range resolves to the identical 6.16.0 silently.

### Why pin instead of `allowedActionOrigins`?

`allowedActionOrigins` is upstream's prescribed remedy and it does work in dev (it matches on host only, so the scheme mismatch stops mattering). But under `@react-router/serve` it is resolved at **config time and baked into the server build** (`@react-router/dev` serializes it into the virtual server-build module), and the `Dockerfile` runs `npm run build` with no app URL available — so it would fix dev while leaving production `npm start` behind a TLS terminator still broken. Upstream does document a **runtime** override — setting `allowedActionOrigins` on the server build object — but only from a custom server, i.e. ejecting from `@react-router/serve` to a custom `@react-router/express` server that reads `SHOPIFY_APP_URL` at startup. That is the durable fix this pin defers to, and it needs a deploy-story change, not a hotfix.

Note that pinning is not a wait-for-upstream measure: maintainers closed the near-identical [#15196](https://github.com/remix-run/react-router/issues/15196) as `NOT_PLANNED`, and the v7.18.0 changelog (“CSRF Check Logic Fix”) had already named `@react-router/serve` and non-`trust proxy` `@react-router/express` as expected casualties, prescribing `allowedActionOrigins`. [#15454](https://github.com/remix-run/react-router/issues/15454) is open and untouched by any maintainer; the only proposed fix, [#15462](https://github.com/remix-run/react-router/pull/15462), has no maintainer review (its sole review, from a non-maintainer, argues `trustProxy` enables host spoofing), targets `main` (v8), patches only the Vite dev adapter, and can't be backported as written (it needs `trustProxy` from `@remix-run/node-fetch-server@0.14.0`, while 7.18.3 pins `^0.13.0`). Moving forward will mean adopting `allowedActionOrigins` with a production story — the Dependabot comment records that as the removal condition.

React Router 8 is not an escape route: every published `@shopify/shopify-app-react-router` version, including the latest 2.1.0, peers on `react-router: ^7.6.2`, and RR8 requires React ≥19.2.7 against this template's React 18. That also means **#262 should be closed** rather than merged.

### What this PR does *not* fix

- **`deepmerge-ts@7.1.5`** ([CVE-2026-40345](https://github.com/advisories/GHSA-ggr8-5vv4-36mx), high) arrives via `prisma` → `@prisma/config`, which pins it at exactly `7.1.5` in *every* released version through 7.10.0. Only 8.0.0 fixes it (7.1.6 shipped one day before the fix merged). It is **not attacker-reachable**: `@prisma/config`'s single use of `deepmerge` is as c12's merger when loading a developer-authored `prisma.config.ts` (with `extend`/`rcFile`/`dotenv`/`giget` all disabled), it runs only in the Prisma CLI, and the built server bundle contains zero references to it. EPSS 0.47%; no CVSS v3 vector (the high label comes from a CVSS v4 8.2, availability-impact-only vector). Overriding it would cross a major boundary against someone else's exact pin, inside the code path that runs `prisma migrate deploy` at container boot — a poor trade against an unreachable stack-overflow bug. `@prisma/config@8.1.0-dev.5/6` already moved to 8.0.2, so this should resolve upstream on its own.
- **Committing a lockfile.** This is the root cause both threads share, and it's a real decision with real trade-offs — CI installs with three package managers, so one committed lockfile can't serve all three, and it changes the template's update model (the template becomes responsible for every transitive bump users receive). It's also why Dependabot structurally cannot see `qs` or `deepmerge-ts` here. Left for the team to decide rather than settled in a hotfix.

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#fix/pin-react-router-7.18.2-and-qs-cve
```

Then `shopify app dev` and click **Generate a product** — it should succeed rather than returning `Error: Bad Request`.

Verification already run:

- The regression was reproduced from first principles in a bare React Router app with no Shopify tooling: identical requests returned **200 on 7.18.2 and 400 on 7.18.3**, on both the document POST and the single-fetch `.data` path, in **both** `react-router dev` and `react-router-serve` production mode. Controls isolated scheme as the only variable (matching the scheme → 200; host mismatch → 400 on both versions; GETs → 200 on both).
- On this branch, npm and pnpm both resolve all six family packages (including the transitive `@react-router/express`) to 7.18.2 with **zero** occurrences of 7.18.3 in either lockfile, and a single `qs@6.16.0` with no copies left at 6.15.3.
- All four CI checks pass on both trees: `tsc --noEmit`, `eslint`, `prisma generate && prisma validate`, `react-router build`. The Docker flow (`npm ci --omit=dev` then `npm run build`) also passes.
- `express@4.22.2` was exercised against `qs@6.16.0` over real HTTP: **zero** behavioural differences vs 6.15.3 across 96 comparisons (nested brackets, `a[]=` arrays, comma values, indexed arrays, arrayLimit overflow, prototype keys, deep nesting). A 756-case differential fuzz of `qs` itself found only two parse differences, both requiring `comma: true` + `throwOnLimitExceeded: true` + a low `arrayLimit` together — options neither express nor body-parser ever set.
- The unpinned control confirms `main` today resolves `react-router@7.18.3` + `qs@6.15.3`.

### Checklist

- [x] I have made changes to the `README.md` file and other related documentation, if applicable — no user-facing docs change; the rationale lives in `CHANGELOG.md` and the Dependabot comment
- [x] I have added an entry to `CHANGELOG.md`
- [x] I'm aware I need to create a new release when this PR is merged

> [!IMPORTANT]
> `shopify app init` scaffolds from **`main-cli`** (TypeScript) and **`javascript-cli`** (JavaScript), not `main` — and the conversion automation cannot carry this change: both `convert-to-javascript.yml` (main-cli → javascript-cli) and `update-javascript-branch.yml` (main → javascript) run `git restore package.json` before committing, so a dependency-only fix never propagates. Direct, hand-tailored mirror PRs are up for every scaffold branch: #281 (`main-cli`), #284 (`javascript-cli`), #285 (`javascript`). (Mirror PR head branches against the JavaScript branches must be named starting with `javascript` — CI's TypeScript step is guarded on the head-branch name — which is why #282/#283 were superseded.) Those mirrors, not this PR, are the user-facing fix; CHANGELOG entries do propagate through the conversion workflows, so only #281 carries one.
