### PR TITLE
[main-cli] Pin React Router to 7.18.2 and force qs to ^6.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @shopify/shopify-app-template-react-router
 
+## 2026.09.03
+- [#280](https://github.com/Shopify/shopify-app-template-react-router/pull/280) - Pin the React Router family to 7.18.2. 7.18.3 tightened action-origin validation to compare the full origin, which made every action return `400 Bad Request` under `shopify app dev` and, in production, behind TLS-terminating proxies that forward to the app over plain HTTP (`react-router-serve` never enables Express `trust proxy`). Fixes [#279](https://github.com/Shopify/shopify-app-template-react-router/issues/279).
+- [#280](https://github.com/Shopify/shopify-app-template-react-router/pull/280) - Force `qs` to `^6.16.0` to clear [CVE-2026-82562](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) and [CVE-2026-82417](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g), which reach the app transitively through `@react-router/serve` → `express@4`.
+
 ## 2026.02.09
 - Add declarative product metafield definition and demonstrate metafield usage in the product creation flow
 - Add declarative metaobject definition and demonstrate metaobject upsert in the product creation flow

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "dependencies": {
     "@prisma/client": "^6.16.3",
-    "@react-router/dev": "^7.12.0",
-    "@react-router/fs-routes": "^7.12.0",
-    "@react-router/node": "^7.12.0",
-    "@react-router/serve": "^7.12.0",
+    "@react-router/dev": "7.18.2",
+    "@react-router/fs-routes": "7.18.2",
+    "@react-router/node": "7.18.2",
+    "@react-router/serve": "7.18.2",
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.2.1",
     "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
@@ -36,7 +36,7 @@
     "prisma": "^6.16.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.12.0",
+    "react-router": "7.18.2",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {
@@ -68,6 +68,15 @@
     "@shopify/plugin-cloudflare"
   ],
   "overrides": {
-    "p-map": "^4.0.0"
+    "p-map": "^4.0.0",
+    "qs": "^6.16.0"
+  },
+  "resolutions": {
+    "qs": "^6.16.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "qs": "^6.16.0"
+    }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #279 **for `shopify app init` TypeScript users** — this branch, not `main`, is what the CLI scaffolds from. Mirror of #280; full rationale, upstream analysis, and verification live there.

In short: `react-router@7.18.3` tightened action-origin validation to a full-origin comparison ([remix-run/react-router#15420](https://github.com/remix-run/react-router/pull/15420)), so under `shopify app dev` (and in production behind plain-HTTP TLS terminators — `react-router-serve` never enables Express `trust proxy`) every action POST returns `400 Bad Request`. Separately, `qs@6.15.3` (via `@react-router/serve` → `express@4`) carries [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) and [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g), fixed in 6.16.0.

### WHAT is this pull request doing?

- Pins the five `react-router` family packages to `7.18.2` (hand-applied — this branch's `package.json` has drifted from `main`, so #280 cannot be cherry-picked).
- Forces `qs` to `^6.16.0` in the same three dialects as #280 (npm `overrides`, `resolutions`, `pnpm.overrides` — CI installs with npm, yarn and pnpm, and each honours a different field).
- Adds the same `CHANGELOG.md` entry. The changelog **does** propagate to `javascript-cli` through the conversion workflow; `package.json` does **not** (the workflow runs `git restore package.json` before committing), which is why there is a companion direct PR against `javascript-cli`.
- Deliberately does **not** mirror the `dependabot.yml` ignore block: Dependabot reads its config from the default branch only and has never targeted `main-cli` (zero historical PRs), so a copy here would be dead config.

### Verification

- `npm install --package-lock-only` on this branch: all six family packages (incl. transitive `@react-router/express`) resolve `7.18.2`, zero `7.18.3`; a single `qs@6.16.0`, zero `6.15.3`; no `ERESOLVE` (`@shopify/shopify-app-react-router@^1.2.1` peers on `react-router ^7.6.2`, satisfied).
- The identical pin + override hunk was verified on #280 under npm, pnpm 8/10, and yarn 1.22 (same resolutions, no warnings).

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/shopify-app-template-react-router#fix/pin-react-router-7.18.2-and-qs-cve-main-cli
```

Then `shopify app dev` and click **Generate a product** — it should succeed rather than returning `Error: Bad Request`.
