### PR TITLE
[javascript] Pin React Router to 7.18.2 and force qs to ^6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "dependencies": {
     "@prisma/client": "^6.16.3",
-    "@react-router/dev": "^7.12.0",
-    "@react-router/fs-routes": "^7.12.0",
-    "@react-router/node": "^7.12.0",
-    "@react-router/serve": "^7.12.0",
+    "@react-router/dev": "7.18.2",
+    "@react-router/fs-routes": "7.18.2",
+    "@react-router/node": "7.18.2",
+    "@react-router/serve": "7.18.2",
     "@shopify/app-bridge-react": "^4.2.4",
     "@shopify/shopify-app-react-router": "^1.1.0",
     "@shopify/shopify-app-session-storage-prisma": "^9.0.0",
@@ -36,7 +36,7 @@
     "prisma": "^6.16.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "^7.12.0",
+    "react-router": "7.18.2",
     "vite-tsconfig-paths": "^5.1.4"
   },
   "devDependencies": {
@@ -68,6 +68,15 @@
     "@shopify/plugin-cloudflare"
   ],
   "overrides": {
-    "p-map": "^4.0.0"
+    "p-map": "^4.0.0",
+    "qs": "^6.16.0"
+  },
+  "resolutions": {
+    "qs": "^6.16.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "qs": "^6.16.0"
+    }
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #279 for apps scaffolded from the `javascript` branch (`shopify app init --template=<url>#javascript`). Mirror of #280 (`main`), #281 (`main-cli`), and the `javascript-cli` companion PR; full rationale and verification live in #280.

A direct PR is required because the `main` → `javascript` conversion workflow (`update-javascript-branch.yml`) runs `git restore package.json` before committing — dependency changes never propagate here through automation.

### WHAT is this pull request doing?

- Pins the five `react-router` family packages to `7.18.2` — `react-router@7.18.3` returns `400 Bad Request` on every action POST under `shopify app dev` ([remix-run/react-router#15420](https://github.com/remix-run/react-router/pull/15420); see #279/#280).
- Forces `qs` to `^6.16.0` (npm `overrides`, `resolutions`, `pnpm.overrides`), clearing [GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx) and [GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g).
- No `CHANGELOG.md` change: the entry propagates via the conversion PR from `main` once #280 merges (the workflow restores only `package.json`).

### Verification

`npm install --package-lock-only` on this branch: all six family packages (incl. transitive `@react-router/express`) resolve `7.18.2`, zero `7.18.3`; a single `qs@6.16.0`, zero `6.15.3`; no `ERESOLVE`. The identical hunk was verified on #280 under npm, pnpm 8/10, and yarn 1.22.
